### PR TITLE
Adding Repeat Intent & Updating with Response Builder

### DIFF
--- a/speech-assets/InteractionModel.json
+++ b/speech-assets/InteractionModel.json
@@ -79,6 +79,17 @@
         "a quiz"
       ],
       "slots": []
+    },
+    {
+      "name": "RepeatIntent",
+      "samples": [
+        "repeat",
+        "say that again",
+        "again",
+        "can i hear the question again",
+        "question again"
+      ],
+      "slots":[]
     }
   ],
   "types": [

--- a/speech-assets/InteractionModel.json
+++ b/speech-assets/InteractionModel.json
@@ -15,6 +15,10 @@
     {
       "name": "AMAZON.StopIntent",
       "samples": []
+    },    
+    {
+      "name": "AMAZON.RepeatIntent",
+      "samples": []
     },
     {
       "name": "AnswerIntent",
@@ -79,17 +83,6 @@
         "a quiz"
       ],
       "slots": []
-    },
-    {
-      "name": "RepeatIntent",
-      "samples": [
-        "repeat",
-        "say that again",
-        "again",
-        "can i hear the question again",
-        "question again"
-      ],
-      "slots":[]
     }
   ],
   "types": [

--- a/speech-assets/intent-schema.json
+++ b/speech-assets/intent-schema.json
@@ -5,7 +5,7 @@
                                         {"name": "Abbreviation", "type": "US_STATE_ABBR"},
                                         {"name": "StatehoodOrder", "type": "AMAZON.NUMBER"}]},
     {"intent": "QuizIntent"},
-    {"intent": "RepeatIntent"},
+    {"intent": "AMAZON.RepeatIntent"},
     {"intent": "AMAZON.StopIntent"},
     {"intent": "AMAZON.CancelIntent"},
     {"intent": "AMAZON.StartOverIntent"},

--- a/speech-assets/intent-schema.json
+++ b/speech-assets/intent-schema.json
@@ -5,6 +5,7 @@
                                         {"name": "Abbreviation", "type": "US_STATE_ABBR"},
                                         {"name": "StatehoodOrder", "type": "AMAZON.NUMBER"}]},
     {"intent": "QuizIntent"},
+    {"intent": "RepeatIntent"},
     {"intent": "AMAZON.StopIntent"},
     {"intent": "AMAZON.CancelIntent"},
     {"intent": "AMAZON.StartOverIntent"},

--- a/speech-assets/sample-utterances.txt
+++ b/speech-assets/sample-utterances.txt
@@ -28,8 +28,3 @@ QuizIntent and start a quiz
 QuizIntent and quiz me
 QuizIntent for a quiz
 QuizIntent a quiz
-
-RepeatIntent repeat
-RepeatIntent say that again
-RepeatIntent again
-RepeatIntent can i hear the question again

--- a/speech-assets/sample-utterances.txt
+++ b/speech-assets/sample-utterances.txt
@@ -28,3 +28,8 @@ QuizIntent and start a quiz
 QuizIntent and quiz me
 QuizIntent for a quiz
 QuizIntent a quiz
+
+RepeatIntent repeat
+RepeatIntent say that again
+RepeatIntent again
+RepeatIntent can i hear the question again

--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,8 @@ const handlers = {
         this.emitWithState("AnswerIntent");
     },
     "AMAZON.HelpIntent": function() {
-        this.emit(":ask", HELP_MESSAGE, HELP_MESSAGE);
+        this.response.speak(HELP_MESSAGE).listen(HELP_MESSAGE);
+        this.emit(":responseReady");
     },
     "Unhandled": function() {
         this.handler.state = states.START;
@@ -204,7 +205,8 @@ const handlers = {
 
 var startHandlers = Alexa.CreateStateHandler(states.START,{
     "Start": function() {
-        this.emit(":ask", WELCOME_MESSAGE, HELP_MESSAGE);
+        this.response.speak(WELCOME_MESSAGE).listen(HELP_MESSAGE);
+        this.emit(":responseReady");
     },
     "AnswerIntent": function() {
         var item = getItem(this.event.request.intent.slots);
@@ -215,18 +217,21 @@ var startHandlers = Alexa.CreateStateHandler(states.START,{
             if (USE_CARDS_FLAG)
             {
                 var imageObj = {smallImageUrl: getSmallImage(item), largeImageUrl: getLargeImage(item)};
-                this.emit(":askWithCard", getSpeechDescription(item), REPROMPT_SPEECH, getCardTitle(item), getTextDescription(item), imageObj);
+
+                this.response.speak(getSpeechDescription(item)).listen(REPROMPT_SPEECH);
+                this.response.cardRenderer(getCardTitle(item), getTextDescription(item), imageObj);
             }
             else
             {
-                this.emit(":ask", getSpeechDescription(item), REPROMPT_SPEECH);
+                this.response.speak(getSpeechDescription(item)).listen(REPROMPT_SPEECH);
             }
         }
         else
         {
-            this.emit(":ask", getBadAnswer(item), getBadAnswer(item));
-
+            this.response.speak(getBadAnswer(item)).listen(getBadAnswer(item));
         }
+
+        this.emit(":responseReady");
     },
     "QuizIntent": function() {
         this.handler.state = states.QUIZ;
@@ -236,13 +241,16 @@ var startHandlers = Alexa.CreateStateHandler(states.START,{
         this.emitWithState("AskQuestion");
     },
     "AMAZON.StopIntent": function() {
-        this.emit(":tell", EXIT_SKILL_MESSAGE);
+        this.response.speak(EXIT_SKILL_MESSAGE);
+        this.emit(":responseReady");
     },
     "AMAZON.CancelIntent": function() {
-        this.emit(":tell", EXIT_SKILL_MESSAGE);
+        this.response.speak(EXIT_SKILL_MESSAGE);
+        this.emit(":responseReady");
     },
     "AMAZON.HelpIntent": function() {
-        this.emit(":ask", HELP_MESSAGE, HELP_MESSAGE);
+        this.response.speak(HELP_MESSAGE).listen(HELP_MESSAGE);
+        this.emit(":responseReady");
     },
     "Unhandled": function() {
         this.emitWithState("Start");
@@ -258,6 +266,7 @@ var quizHandlers = Alexa.CreateStateHandler(states.QUIZ,{
         this.emitWithState("AskQuestion");
     },
     "AskQuestion": function() {
+
         if (this.attributes["counter"] == 0)
         {
             this.attributes["response"] = START_QUIZ_MESSAGE + " ";
@@ -272,19 +281,27 @@ var quizHandlers = Alexa.CreateStateHandler(states.QUIZ,{
         this.attributes["quizitem"] = item;
         this.attributes["quizproperty"] = property;
         
-        if(!this.attributes["isRepeat"]){
-            this.attributes["counter"]++;            
+        if (!this.attributes["isRepeat"]) {
+            this.attributes["counter"]++;
+
+            var question = getQuestion(this.attributes["counter"], property, item);
+            var speech = this.attributes["response"] + question;
+
+            this.response.speak(speech).listen(question);  
+
         } else {
+
             this.attributes["isRepeat"] = false;
+            var question = getQuestion(this.attributes["counter"], property, item);            
+            this.response.speak(question);
+
         }
 
-        var question = getQuestion(this.attributes["counter"], property, item);
-        var speech = this.attributes["response"] + question;
-
-        this.emit(":ask", speech, question);
+        this.emit(":responseReady");
     },
     "AnswerIntent": function() {
         var response = "";
+        var speechOutput = "";
         var item = this.attributes["quizitem"];
         var property = this.attributes["quizproperty"]
 
@@ -311,7 +328,10 @@ var quizHandlers = Alexa.CreateStateHandler(states.QUIZ,{
         else
         {
             response += getFinalScore(this.attributes["quizscore"], this.attributes["counter"]);
-            this.emit(":tell", response + " " + EXIT_SKILL_MESSAGE);
+            speechOutput = response + " " + EXIT_SKILL_MESSAGE;
+
+            this.response.speak(speechOutput);
+            this.emit(":responseReady");
         }
     },
     "RepeatIntent": function() {
@@ -322,13 +342,16 @@ var quizHandlers = Alexa.CreateStateHandler(states.QUIZ,{
         this.emitWithState("Quiz");
     },
     "AMAZON.StopIntent": function() {
-        this.emit(":tell", EXIT_SKILL_MESSAGE);
+        this.response.speak(EXIT_SKILL_MESSAGE);
+        this.emit(":responseReady");
     },
     "AMAZON.CancelIntent": function() {
-        this.emit(":tell", EXIT_SKILL_MESSAGE);
+        this.response.speak(EXIT_SKILL_MESSAGE);
+        this.emit(":responseReady");
     },
     "AMAZON.HelpIntent": function() {
-        this.emit(":ask", HELP_MESSAGE, HELP_MESSAGE);
+        this.response.speak(HELP_MESSAGE).listen(HELP_MESSAGE);
+        this.emit(":responseReady");
     },
     "Unhandled": function() {
         this.emitWithState("AnswerIntent");

--- a/src/index.js
+++ b/src/index.js
@@ -232,6 +232,9 @@ var startHandlers = Alexa.CreateStateHandler(states.START,{
         this.handler.state = states.QUIZ;
         this.emitWithState("Quiz");
     },
+    "RepeatIntent": function() {
+        this.emitWithState("AskQuestion");
+    },
     "AMAZON.StopIntent": function() {
         this.emit(":tell", EXIT_SKILL_MESSAGE);
     },
@@ -268,7 +271,12 @@ var quizHandlers = Alexa.CreateStateHandler(states.QUIZ,{
 
         this.attributes["quizitem"] = item;
         this.attributes["quizproperty"] = property;
-        this.attributes["counter"]++;
+        
+        if(!this.attributes["isRepeat"]){
+            this.attributes["counter"]++;            
+        } else {
+            this.attributes["isRepeat"] = false;
+        }
 
         var question = getQuestion(this.attributes["counter"], property, item);
         var speech = this.attributes["response"] + question;
@@ -305,6 +313,10 @@ var quizHandlers = Alexa.CreateStateHandler(states.QUIZ,{
             response += getFinalScore(this.attributes["quizscore"], this.attributes["counter"]);
             this.emit(":tell", response + " " + EXIT_SKILL_MESSAGE);
         }
+    },
+    "RepeatIntent": function() {
+        this.attributes["isRepeat"] = true;
+        this.emitWithState("AskQuestion");
     },
     "AMAZON.StartOverIntent": function() {
         this.emitWithState("Quiz");

--- a/src/index.js
+++ b/src/index.js
@@ -28,16 +28,16 @@ function getQuestion(counter, property, item)
     switch(property)
     {
         case "City":
-            return "Here is your " + counter + "th question.  In what city do the " + item.League + "'s "  + item.Mascot + " play?";
+            return "Here is question number " + counter + ". In what city do the " + item.League + "'s "  + item.Mascot + " play?";
         break;
         case "Sport":
-            return "Here is your " + counter + "th question.  What sport do the " + item.City + " " + item.Mascot + " play?";
+            return "Here is question number " + counter + ". What sport do the " + item.City + " " + item.Mascot + " play?";
         break;
         case "HeadCoach":
-            return "Here is your " + counter + "th question.  Who is the head coach of the " + item.City + " " + item.Mascot + "?";
+            return "Here is question number " + counter + ". Who is the head coach of the " + item.City + " " + item.Mascot + "?";
         break;
         default:
-            return "Here is your " + counter + "th question.  What is the " + formatCasing(property) + " of the "  + item.Mascot + "?";
+            return "Here is question number " + counter + ". What is the " + formatCasing(property) + " of the "  + item.Mascot + "?";
         break;
     }
     */

--- a/src/index.js
+++ b/src/index.js
@@ -237,7 +237,7 @@ var startHandlers = Alexa.CreateStateHandler(states.START,{
         this.handler.state = states.QUIZ;
         this.emitWithState("Quiz");
     },
-    "RepeatIntent": function() {
+    "AMAZON.RepeatIntent": function() {
         this.emitWithState("AskQuestion");
     },
     "AMAZON.StopIntent": function() {
@@ -324,7 +324,7 @@ var quizHandlers = Alexa.CreateStateHandler(states.QUIZ,{
             this.emit(":responseReady");
         }
     },
-    "RepeatIntent": function() {
+    "AMAZON.RepeatIntent": function() {
         var question = getQuestion(this.attributes["counter"], this.attributes["quizproperty"], this.attributes["quizitem"]);
         this.response.speak(question).listen(question);
         this.emit(":responseReady");

--- a/src/index.js
+++ b/src/index.js
@@ -281,22 +281,12 @@ var quizHandlers = Alexa.CreateStateHandler(states.QUIZ,{
         this.attributes["quizitem"] = item;
         this.attributes["quizproperty"] = property;
         
-        if (!this.attributes["isRepeat"]) {
-            this.attributes["counter"]++;
+        this.attributes["counter"]++;
 
-            var question = getQuestion(this.attributes["counter"], property, item);
-            var speech = this.attributes["response"] + question;
+        var question = getQuestion(this.attributes["counter"], property, item);
+        var speech = this.attributes["response"] + question;
 
-            this.response.speak(speech).listen(question);  
-
-        } else {
-
-            this.attributes["isRepeat"] = false;
-            var question = getQuestion(this.attributes["counter"], property, item);            
-            this.response.speak(question);
-
-        }
-
+        this.response.speak(speech).listen(question);  
         this.emit(":responseReady");
     },
     "AnswerIntent": function() {
@@ -335,8 +325,9 @@ var quizHandlers = Alexa.CreateStateHandler(states.QUIZ,{
         }
     },
     "RepeatIntent": function() {
-        this.attributes["isRepeat"] = true;
-        this.emitWithState("AskQuestion");
+        var question = getQuestion(this.attributes["counter"], this.attributes["quizproperty"], this.attributes["quizitem"]);
+        this.response.speak(question).listen(question);
+        this.emit(":responseReady");
     },
     "AMAZON.StartOverIntent": function() {
         this.emitWithState("Quiz");

--- a/src/index.js
+++ b/src/index.js
@@ -22,22 +22,23 @@ function getSpeechDescription(item)
 //structure for each property of your data.
 function getQuestion(counter, property, item)
 {
-    return "Here is question number " + counter + ". What is the " + formatCasing(property) + " of "  + item.StateName + "?";
+    //Alexa will handle how the ordinals are pronounced. She'll correctly say "first" instead of "1th", or "second" instead of "2th"
+    return "Here is the " + counter + "th question. What is the " + formatCasing(property) + " of "  + item.StateName + "?";
 
     /*
     switch(property)
     {
         case "City":
-            return "Here is question number " + counter + ". In what city do the " + item.League + "'s "  + item.Mascot + " play?";
+            return "Here is the " + counter + "th question. In what city do the " + item.League + "'s "  + item.Mascot + " play?";
         break;
         case "Sport":
-            return "Here is question number " + counter + ". What sport do the " + item.City + " " + item.Mascot + " play?";
+            return "Here is the " + counter + "th question. What sport do the " + item.City + " " + item.Mascot + " play?";
         break;
         case "HeadCoach":
-            return "Here is question number " + counter + ". Who is the head coach of the " + item.City + " " + item.Mascot + "?";
+            return "Here is the " + counter + "th question. Who is the head coach of the " + item.City + " " + item.Mascot + "?";
         break;
         default:
-            return "Here is question number " + counter + ". What is the " + formatCasing(property) + " of the "  + item.Mascot + "?";
+            return "Here is the " + counter + "th question. What is the " + formatCasing(property) + " of the "  + item.Mascot + "?";
         break;
     }
     */

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function getSpeechDescription(item)
 //structure for each property of your data.
 function getQuestion(counter, property, item)
 {
-    return "Here is your " + counter + "th question.  What is the " + formatCasing(property) + " of "  + item.StateName + "?";
+    return "Here is question number " + counter + ". What is the " + formatCasing(property) + " of "  + item.StateName + "?";
 
     /*
     switch(property)


### PR DESCRIPTION
**Summary:**
When we start a quiz after launching the skill, the skill provides questions and if user requests to repeat the question, the skill continues the game which isn't a great user experience. Adding a Repeat Intent to the interaction model to resolve this.

**Changes:**

- Added Repeat Intent
- Updated Intent Handlers to use response builder API from SDK

**Addresses the following trouble ticket:**
https://tt.amazon.com/0120434489

**Reviewers:**
@jeffblankenburg @PaulCutsinger @robm26 @SleepyDeveloper @ajot @memodoring 
